### PR TITLE
version updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Applitools Example: Basic Selenium WebDriver in Java
 
-This is the example project for the [Selenium Java Basic tutorial](https://applitools.com/tutorials/quickstart/web/selenium/java/basic).
+This is the example project for the [Selenium Java Basic tutorial](https://applitools.com/tutorials).
 It shows how to start automating visual tests
 with [Applitools Eyes](https://applitools.com/platform/eyes/)
 and [Selenium WebDriver](https://www.selenium.dev/) in Java.
@@ -25,14 +25,19 @@ To run this example project, you'll need:
 3. A good Java editor, such as [JetBrains IntelliJ IDEA](https://www.jetbrains.com/idea/).
 4. [Apache Maven](https://maven.apache.org/download.cgi) (typically bundled with IDEs).
 5. An up-to-date version of [Google Chrome](https://www.google.com/chrome/downloads/).
-6. A corresponding version of [ChromeDriver](https://chromedriver.chromium.org/downloads).
 
 The main test case is [`AcmeBankTests.java`](src/test/java/com/applitools/example/AcmeBankTests.java).
 By default, the project will run tests with Ultrafast Grid but not Execution Cloud.
 You can change these settings in the test class.
 
 To execute tests, set the `APPLITOOLS_API_KEY` environment variable
-to your [account's API key](https://applitools.com/tutorials/guides/getting-started/registering-an-account).
+to your [account's API key](https://applitools.com/tutorials/getting-started/registering-an-account).
+
+Install the dependencies
+```
+mvn install
+```
+
 You can launch the test from your IDE,
 or you can run it from the command line with Maven like this:
 
@@ -41,4 +46,4 @@ mvn exec:exec@run-the-tests -Dexec.classpathScope=test
 ```
 
 **For full instructions on running this project, take our
-[Selenium Java Basic tutorial](https://applitools.com/tutorials/quickstart/web/selenium/java/basic)!**
+[Selenium Java Basic tutorial](https://applitools.com/tutorials)!**

--- a/pom.xml
+++ b/pom.xml
@@ -17,19 +17,39 @@
         <dependency>
             <groupId>com.applitools</groupId>
             <artifactId>eyes-selenium-java5</artifactId>
-            <version>5.80.0</version>
+            <version>5.81.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>4.10.0</version>
+            <version>4.35.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.6.1</version>
+                <executions>
+                <execution>
+                    <id>enforce-maven</id>
+                    <goals>
+                    <goal>enforce</goal>
+                    </goals>
+                    <configuration>
+                    <rules>
+                        <requireMavenVersion>
+                        <version>3.6.1</version>
+                        </requireMavenVersion>
+                    </rules>    
+                    </configuration>
+                </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.example</groupId>
     <artifactId>example-selenium-java-basic</artifactId>
-    <version>2.1.1</version>
+    <version>2.1.2</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
- Dependency package updates
- Updates to README fix broken links
- Added missing `install the dependencies` section
- removed the call out for chromedriver install separately, this is no longer needed since selenium 4.6
- bumped version